### PR TITLE
Add headline display to S3 box 3 idle page

### DIFF
--- a/esp32-s3-box-3/esp32-s3-box-3.yaml
+++ b/esp32-s3-box-3/esp32-s3-box-3.yaml
@@ -730,6 +730,22 @@ font:
     size: 40
     glyphsets:
       - ${font_glyphsets}
+  - file:
+      type: gfonts
+      family: ${font_family}
+      weight: 600
+    id: font_headline_text
+    size: 26
+    glyphsets:
+      - ${font_glyphsets}
+  - file:
+      type: gfonts
+      family: ${font_family}
+      weight: 300
+    id: font_headline_subtitle
+    size: 20
+    glyphsets:
+      - ${font_glyphsets}
 
 text_sensor:
   - id: text_request
@@ -751,6 +767,14 @@ text_sensor:
           std::string truncated = esphome::str_truncate(name.c_str(),31);
           id(text_response).state = (truncated+"...").c_str();
         }
+
+  - platform: homeassistant
+    id: headline_text
+    entity_id: input_text.display_headline_text
+
+  - platform: homeassistant
+    id: headline_subtitle
+    entity_id: input_text.display_headline_subtitle
 
 #  - platform: homeassistant
 #    id: outside_weather_sensor
@@ -823,6 +847,10 @@ display:
 
           // Piirrä sivu
           it.fill(id(idle_color));
+          // Piirrä otsikkoruutu keltaisella reunalla
+          it.rectangle(20, 80, 280, 80, Color(0xFF, 0xFF, 0x00));
+          it.printf(it.get_width() / 2, 100, id(font_headline_text), Color::WHITE, TextAlign::CENTER, "%s", id(headline_text).state.c_str());
+          it.printf(it.get_width() / 2, 130, id(font_headline_subtitle), Color::WHITE, TextAlign::CENTER, "%s", id(headline_subtitle).state.c_str());
           // Kellonaika näytöllä
           // Piirrä tunnit & kaksoispiste valkoisella
           it.printf(165, 182, id(font_clock), Color::WHITE, TextAlign::RIGHT, hour_colon);


### PR DESCRIPTION
## Summary
- show custom headline text on idle display
- retrieve headline text and subtitle from Home Assistant
- add new fonts for headline elements

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686cc3acc5fc832b93d5672320fac993