### PR TITLE
Round laundry times and use red accents

### DIFF
--- a/esp32-s3-box-3/esp32-s3-box-3.yaml
+++ b/esp32-s3-box-3/esp32-s3-box-3.yaml
@@ -856,9 +856,13 @@ sensor:
   - platform: homeassistant
     id: washing_machine_remaining_time
     entity_id: sensor.washing_machine_remaining_time
+    filters:
+      - round: 0
   - platform: homeassistant
     id: tumble_dryer_remaining_time
     entity_id: sensor.tumble_dryer_remaining_time
+    filters:
+      - round: 0
 
 display:
   - platform: ili9xxx
@@ -890,10 +894,10 @@ display:
           sprintf(temp_str, "%.0f°C", temp);
           // Piirrä sivu
           it.fill(id(idle_color));
-          // Piirrä otsikkoruutu keltaisella reunalla vain jos tekstiä on
+          // Piirrä otsikkoruutu punaisella reunalla vain jos tekstiä on
           if (id(headline_text).state.length() > 0 || id(headline_subtitle).state.length() > 0) {
             for (int i = 0; i < 3; i++) {
-              it.rectangle(20 + i, 80 + i, 280 - 2 * i, 80 - 2 * i, Color(0xFF, 0xFF, 0x00));
+              it.rectangle(20 + i, 80 + i, 280 - 2 * i, 80 - 2 * i, Color(0xC0, 0x00, 0x00));
             }
             it.printf(it.get_width() / 2, 100, id(font_headline_text), Color::WHITE, TextAlign::CENTER, "%s", id(headline_text).state.c_str());
             it.printf(it.get_width() / 2, 130, id(font_headline_subtitle), Color::WHITE, TextAlign::CENTER, "%s", id(headline_subtitle).state.c_str());
@@ -946,7 +950,7 @@ display:
               float interval_index = minutes_since_midnight / interval_minutes;
               int now_x = gx + (interval_index * step);
               now_x = std::min(gx + gw, std::max(gx, now_x));
-              it.line(now_x, gy, now_x, gy + gh, Color(0xFF,0xFF,0x00));
+              it.line(now_x, gy, now_x, gy + gh, Color(0xC0,0x00,0x00));
             }
           }
 
@@ -960,7 +964,7 @@ display:
           }
           Color price_color = Color::WHITE;
           if (electricity_price_cents >= 15.0f) price_color = Color(0xFF,0x00,0x00);
-          else if (electricity_price_cents >= 10.0f) price_color = Color(0xFF,0xFF,0x00);
+          else if (electricity_price_cents >= 10.0f) price_color = Color(0xC0,0x00,0x00);
 
           float power_now = id(power_sensor).state;
           char power_text[16];
@@ -988,8 +992,8 @@ display:
           // Kellonaika näytöllä
           // Piirrä tunnit & kaksoispiste valkoisella
           it.printf(165, 182, id(font_clock), Color::WHITE, TextAlign::RIGHT, hour_colon);
-          // Piirrä minuutit keltaisella
-          it.printf(165, 182, id(font_clock), Color(0xFF, 0xFF, 0x00), TextAlign::LEFT, minute_str);
+          // Piirrä minuutit punaisella
+          it.printf(165, 182, id(font_clock), Color(0xC0, 0x00, 0x00), TextAlign::LEFT, minute_str);
           // Lämpötila ja sää näytöllä
           // Sähkön hinta ja virrankulutus vasemmassa yläkulmassa
           it.printf(10, 10, id(font_mdi), price_color, "󰆭");
@@ -998,7 +1002,7 @@ display:
           it.printf(45, 44, id(font_energy), power_color, "%s", power_text);
 
           it.printf(190, 10, id(font_weather_icon), Color::WHITE, weather_icon);
-          it.printf(it.get_width() - 10, 10, id(font_temp), Color(0xFF, 0xFF, 0x00), TextAlign::RIGHT, temp_str);
+          it.printf(it.get_width() - 10, 10, id(font_temp), Color(0xC0, 0x00, 0x00), TextAlign::RIGHT, temp_str);
           it.printf(it.get_width() - 10, 48, id(font_temp), Color::WHITE, TextAlign::RIGHT, "%s", weather_state.c_str());
 
           // Näytä kalenteritieto


### PR DESCRIPTION
## Summary
- round washing machine and tumble dryer remaining time sensors to whole minutes for display
- switch display accent elements from yellow to a Christmas red theme
- update comments to reflect the new color accents

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a89fef604832bbf0d5a7293b1fe26)